### PR TITLE
chore(ci): Use latest OSs

### DIFF
--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12, windows-2022]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         allow-net: [true, false]
       fail-fast: false
     defaults:


### PR DESCRIPTION
`macos-12` has been turned off. I don't think we need to pin these. If we do, we should add a comment, so that next time we'll know why it's like this.